### PR TITLE
Add Facebook post checker modules and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # Ai-FBPostchecker888
+
 ระบบวิเคราะห์ความเสี่ยงของโพสต์ Facebook ด้วย AI ตรวจจับคำผิดนโยบาย แยกระดับความเสี่ยง พร้อมแจ้งเตือนผ่าน LINE และบันทึกลง Google Sheets โดยอัตโนมัติ.
+
+## Installation
+
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+## Configuration
+
+1. Copy `config/config.example.json` to `config/config.json` and fill in the required tokens and IDs.
+2. Create a Google Cloud service account and download the credentials JSON referenced in the config.
+3. Make sure the service account has access to the target Google Sheet.
+
+## Usage
+
+The following snippet checks the most recent posts of the configured Facebook page and performs policy detection, risk classification, notifications, and logging:
+
+```python
+from src.config_loader import load_config
+from src.post_checker import PostChecker
+
+config = load_config("config/config.json")
+checker = PostChecker(
+    fb_token=config.facebook_token,
+    page_id=config.facebook_page_id,
+    line_token=config.line_token,
+    gs_creds_file=config.google_credentials_file,
+    gs_sheet_id=config.google_sheet_id,
+    banned_keywords=config.banned_keywords,
+)
+checker.run(limit=10)
+```
+
+The script uses the Facebook Graph API to retrieve posts, flags posts that contain banned keywords, classifies risk level, sends a notification via LINE, and appends the results to a Google Sheet.

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,0 +1,16 @@
+{
+  "facebook": {
+    "access_token": "YOUR_FACEBOOK_ACCESS_TOKEN",
+    "page_id": "YOUR_FACEBOOK_PAGE_ID"
+  },
+  "line": {
+    "token": "YOUR_LINE_NOTIFY_TOKEN"
+  },
+  "google_sheets": {
+    "credentials_file": "path/to/credentials.json",
+    "sheet_id": "YOUR_SHEET_ID"
+  },
+  "policy": {
+    "banned_keywords": ["ban", "forbidden", "secret"]
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+facebook-sdk>=3.1.0
+requests>=2.0
+gspread>=5.0.0
+oauth2client>=4.1.3

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,30 @@
+"""Configuration utilities for the post checker."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Config:
+    facebook_token: str
+    facebook_page_id: str
+    line_token: str
+    google_credentials_file: str
+    google_sheet_id: str
+    banned_keywords: List[str]
+
+
+def load_config(path: str) -> Config:
+    """Load configuration from ``path`` and return a :class:`Config` instance."""
+    with open(path, "r", encoding="utf8") as fh:
+        data = json.load(fh)
+    return Config(
+        facebook_token=data["facebook"]["access_token"],
+        facebook_page_id=data["facebook"]["page_id"],
+        line_token=data["line"]["token"],
+        google_credentials_file=data["google_sheets"]["credentials_file"],
+        google_sheet_id=data["google_sheets"]["sheet_id"],
+        banned_keywords=data.get("policy", {}).get("banned_keywords", []),
+    )

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -1,0 +1,31 @@
+"""Facebook API client module."""
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+try:
+    from facebook import GraphAPI
+except Exception:  # pragma: no cover - library might not be installed during tests
+    GraphAPI = None  # type: ignore
+
+
+class FacebookClient:
+    """Small wrapper around the Facebook Graph API.
+
+    Parameters
+    ----------
+    access_token:
+        Token with the required permissions to read posts from a page.
+    version:
+        API version to use. Defaults to ``3.1`` which is widely available.
+    """
+
+    def __init__(self, access_token: str, version: str = "3.1") -> None:
+        if GraphAPI is None:
+            raise ImportError("facebook-sdk library is required but not installed")
+        self.graph = GraphAPI(access_token=access_token, version=version)
+
+    def get_page_posts(self, page_id: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return recent posts from the specified page."""
+        data = self.graph.get_connections(page_id, "posts", limit=limit)
+        return data.get("data", [])

--- a/src/google_sheets_logger.py
+++ b/src/google_sheets_logger.py
@@ -1,0 +1,30 @@
+"""Utilities for logging data to Google Sheets."""
+from __future__ import annotations
+
+from typing import List
+
+try:
+    import gspread
+    from oauth2client.service_account import ServiceAccountCredentials
+except Exception:  # pragma: no cover - libraries might not be installed
+    gspread = None  # type: ignore
+    ServiceAccountCredentials = None  # type: ignore
+
+
+class GoogleSheetsLogger:
+    """Append rows to a Google Sheet using a service account."""
+
+    def __init__(self, creds_file: str, sheet_id: str) -> None:
+        if gspread is None or ServiceAccountCredentials is None:
+            raise ImportError("gspread and oauth2client are required but not installed")
+        scope = [
+            "https://spreadsheets.google.com/feeds",
+            "https://www.googleapis.com/auth/drive",
+        ]
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(creds_file, scope)
+        client = gspread.authorize(credentials)
+        self.sheet = client.open_by_key(sheet_id).sheet1
+
+    def log(self, post_id: str, message: str, risk: str) -> None:
+        """Append a new row to the sheet."""
+        self.sheet.append_row([post_id, message, risk])

--- a/src/line_notifier.py
+++ b/src/line_notifier.py
@@ -1,0 +1,20 @@
+"""Simple LINE Notify client."""
+from __future__ import annotations
+
+import requests
+
+
+class LineNotifier:
+    """Send push notifications using the LINE Notify API."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def send(self, message: str) -> None:
+        response = requests.post(
+            "https://notify-api.line.me/api/notify",
+            headers={"Authorization": f"Bearer {self._token}"},
+            data={"message": message},
+            timeout=10,
+        )
+        response.raise_for_status()

--- a/src/policy_detector.py
+++ b/src/policy_detector.py
@@ -1,0 +1,41 @@
+"""Policy detection and risk classification helpers."""
+from __future__ import annotations
+
+from typing import Iterable, Tuple, List
+
+
+class PolicyDetector:
+    """Detects whether a post violates configured policies.
+
+    The detector performs a very small rule based check on whether any of the
+    banned keywords appear in the text of a post.
+    """
+
+    def __init__(self, banned_keywords: Iterable[str] | None = None) -> None:
+        self._keywords = set(k.lower() for k in banned_keywords or [])
+
+    def detect(self, text: str) -> Tuple[bool, str]:
+        """Return a tuple ``(violation, reason)`` for the supplied text."""
+        lowered = text.lower()
+        offending: List[str] = [k for k in self._keywords if k in lowered]
+        if offending:
+            reason = f"Found banned keywords: {', '.join(offending)}"
+            return True, reason
+        return False, ""
+
+
+class RiskClassifier:
+    """Classify the risk level of a post.
+
+    The classifier is intentionally extremely small – it merely looks for a
+    handful of words associated with high risk posts.  Real deployments would
+    likely use machine learning based systems.
+    """
+
+    _high_risk_terms = {"urgent", "alert", "warning"}
+
+    def classify(self, text: str) -> str:
+        lowered = text.lower()
+        if any(term in lowered for term in self._high_risk_terms):
+            return "high"
+        return "low"

--- a/src/post_checker.py
+++ b/src/post_checker.py
@@ -1,0 +1,42 @@
+"""High level orchestration for the Facebook post checker."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from .facebook_client import FacebookClient
+from .policy_detector import PolicyDetector, RiskClassifier
+from .line_notifier import LineNotifier
+from .google_sheets_logger import GoogleSheetsLogger
+
+
+class PostChecker:
+    """Check Facebook posts against policies and perform side effects."""
+
+    def __init__(
+        self,
+        fb_token: str,
+        page_id: str,
+        line_token: str,
+        gs_creds_file: str,
+        gs_sheet_id: str,
+        banned_keywords: Iterable[str] | None = None,
+    ) -> None:
+        self.page_id = page_id
+        self.fb = FacebookClient(fb_token)
+        self.detector = PolicyDetector(banned_keywords)
+        self.classifier = RiskClassifier()
+        self.notifier = LineNotifier(line_token)
+        self.logger = GoogleSheetsLogger(gs_creds_file, gs_sheet_id)
+
+    def run(self, limit: int = 10) -> None:
+        """Fetch recent posts and handle policy checks."""
+        posts = self.fb.get_page_posts(self.page_id, limit=limit)
+        for post in posts:
+            message = post.get("message", "")
+            violation, reason = self.detector.detect(message)
+            risk = self.classifier.classify(message)
+
+            if violation or risk == "high":
+                note = f"Post {post['id']} flagged: {reason} (risk={risk})"
+                self.notifier.send(note)
+            self.logger.log(post["id"], message, risk)


### PR DESCRIPTION
## Summary
- add modular Facebook post checker with policy detection, risk classification, LINE notifications and Google Sheets logging
- provide sample configuration and loader for tokens and IDs
- document installation, configuration and usage instructions

## Testing
- `python -m py_compile src/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688df0cb9f90832e8382d59d77cd7e60