### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/bowbozaa/Ai-FBPostchecker888/security/code-scanning/1](https://github.com/bowbozaa/Ai-FBPostchecker888/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block to restrict the `GITHUB_TOKEN` to the least privilege required. Since the workflow only checks out code and runs shell commands, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the top level of the workflow (after the `name:` key and before `jobs:`), setting `contents: read`. This will apply to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
